### PR TITLE
QuickContact Expand/Collapse Button removal fixed

### DIFF
--- a/src/com/android/contacts/quickcontact/ExpandingEntryCardView.java
+++ b/src/com/android/contacts/quickcontact/ExpandingEntryCardView.java
@@ -416,7 +416,7 @@ public class ExpandingEntryCardView extends CardView {
             mEntriesViewGroup.addView(view);
         }
 
-        removeView(mExpandCollapseButton);
+        mContainer.removeView(mExpandCollapseButton);
         if (mCollapsedEntriesCount < mNumEntries
                 && mExpandCollapseButton.getParent() == null && !mIsAlwaysExpanded) {
             mContainer.addView(mExpandCollapseButton, -1);


### PR DESCRIPTION
When QuckContact is displayed, if there are 4 or more contact
fields (email/phone#/etc...), then an Expand/Collapse button is
displayed (More/Less). When the contact is edited and only 3
fields remain, this button is supposed to be removed, but was
remaining in the view.

Change-Id: Ic8b55a4bc551a4b05eda5cead96b4bcf4fa2b624
Ticket-Id: Cyngnos-2225