### PR TITLE
Fix NPE in Contact Card

### DIFF
--- a/src/com/android/contacts/quickcontact/QuickContactActivity.java
+++ b/src/com/android/contacts/quickcontact/QuickContactActivity.java
@@ -2315,7 +2315,9 @@ public class QuickContactActivity extends ContactsActivity implements
 
         // override transitions to skip the standard window animations
         overridePendingTransition(0, 0);
-        mBlockContactHelper.destroy();
+        if (mBlockContactHelper != null) {
+            mBlockContactHelper.destroy();
+        }
     }
 
     private final LoaderCallbacks<List<ContactInteraction>> mLoaderInteractionsCallbacks =


### PR DESCRIPTION
Caused by: java.lang.NullPointerException:
   Attempt to invoke virtual method 'void com.android.contacts.common.util.BlockContactHelper.destroy()' on a null object reference
	at com.android.contacts.quickcontact.QuickContactActivity.finish(QuickContactActivity.java:2318)
	at com.android.contacts.quickcontact.QuickContactActivity.processIntent(QuickContactActivity.java:934)
	at com.android.contacts.quickcontact.QuickContactActivity.onCreate(QuickContactActivity.java:875)

Change-Id: I624ca68971079e15b0b9370835533fc4a88e2448
Issue-Id: CYNGNOS-2272