### PR TITLE
Contacts : Remove silent option from ringtone

### DIFF
--- a/src/com/android/contacts/editor/ContactEditorBaseFragment.java
+++ b/src/com/android/contacts/editor/ContactEditorBaseFragment.java
@@ -920,8 +920,8 @@ abstract public class ContactEditorBaseFragment extends Fragment implements
         intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
         // Show only ringtones
         intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_RINGTONE);
-        // Allow the user to pick a silent ringtone
-        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true);
+        // Remove silent option from ringtone
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, false);
 
         final Uri ringtoneUri;
         if (mCustomRingtone != null) {


### PR DESCRIPTION
Silent is fundamentally broken across the platform, its currently
the same as default anyway. A lot of assumptions are based on this
"bug" such as default multi-sim ringtones...etc

Remove the option for now as it doesn't work anyway.

Issue-id: FEIJ-939
Change-Id: I3ce669c8c5f078349054faa0eb29486a3755ce43