### PR TITLE
[2/4] Add cancel callback for BlockContactDialog

### DIFF
--- a/src/com/android/contacts/quickcontact/QuickContactActivity.java
+++ b/src/com/android/contacts/quickcontact/QuickContactActivity.java
@@ -535,6 +535,11 @@ public class QuickContactActivity extends ContactsActivity implements
     };
 
     @Override
+    public void onBlockCancelled() {
+        // Do nothing
+    }
+
+    @Override
     public void onBlockSelected(boolean notifyLookupProvider) {
         mBlockContactHelper.blockContactAsync(notifyLookupProvider);
     }


### PR DESCRIPTION
Some ui elements need to refresh themselves when the dialog
is cancelled. This allows them to do that.

Change-Id: Iffa1861da93b4e070ace0168c3bccafcdf07b5a7
Ticket: CYNGNOS-3111