### PR TITLE
Contacts : fix quick contacts card invite entry

### DIFF
--- a/src/com/android/contacts/quickcontact/ExpandingEntryCardView.java
+++ b/src/com/android/contacts/quickcontact/ExpandingEntryCardView.java
@@ -899,6 +899,13 @@ public class ExpandingEntryCardView extends CardView {
             thirdTextView.setTag(new EntryTag(entry.getId(), entry.getThirdIntent(), entry));
             thirdTextView.setTextColor(mThemeColor);
             thirdTextView.setVisibility(View.VISIBLE);
+            // set rule to make sure the header wraps before the third text
+            if (header != null) {
+                RelativeLayout.LayoutParams headerLayoutParams =
+                        (RelativeLayout.LayoutParams) header.getLayoutParams();
+                headerLayoutParams.addRule(RelativeLayout.START_OF, thirdTextView.getId());
+                header.setLayoutParams(headerLayoutParams);
+            }
         } else {
             thirdTextView.setVisibility(View.GONE);
         }


### PR DESCRIPTION
-QuickContactsCard's InCall "directory search" may be too long in certain
languages and overlap with the "invite" text, need to line wrap

Change-Id: Id5d6f069a657480ac63a928d37dd8adcc111d813
Issue-Id: CD-3117